### PR TITLE
Fix icons

### DIFF
--- a/src/pages/download.tsx
+++ b/src/pages/download.tsx
@@ -21,7 +21,7 @@ const index = () => {
           </Grid>
           <Grid xs={6}>
             <Card shadow hoverable width="100%" paddingTop="40px">
-              <Image draggable="false" src="/assets/icons/arm.png" height="100%" width="170px" marginBottom="20px" />
+              <Image draggable="false" src="/assets/icons/ARM.png" height="100%" width="170px" marginBottom="20px" />
               <Button className="downloadBtn" margin="10px">
                 Direct Download
               </Button>
@@ -30,7 +30,7 @@ const index = () => {
           </Grid>
           <Grid xs={6}>
             <Card shadow hoverable width="100%" paddingTop="40px">
-              <Image draggable="false" src="/assets/icons/arm64.png" height="100%" width="170px" marginBottom="20px" />
+              <Image draggable="false" src="/assets/icons/ARM64.png" height="100%" width="170px" marginBottom="20px" />
               <Button className="downloadBtn" margin="10px">
                 Direct Download
               </Button>


### PR DESCRIPTION
During localhost testing, asset urls are not CaSe SeNsItIvE, which breaks the website when deployed to GitHub. This PR is a simple capitalization fix. 